### PR TITLE
git-cl: Add support for setting Bot-Commit+1 on upload.

### DIFF
--- a/git_cl.py
+++ b/git_cl.py
@@ -2253,6 +2253,8 @@ class Changelist(object):
 
     if options.enable_auto_submit:
       refspec_opts.append('l=Auto-Submit+1')
+    if options.set_bot_commit:
+      refspec_opts.append('l=Bot-Commit+1')
     if options.use_commit_queue:
       refspec_opts.append('l=Commit-Queue+2')
     elif options.cq_dry_run:
@@ -4015,6 +4017,8 @@ def CMDupload(parser, args):
                     action='store_true', default=False,
                     help='Send the patchset to do a CQ dry run right after '
                          'upload.')
+  parser.add_option('--set-bot-commit', action='store_true',
+                    help=optparse.SUPPRESS_HELP)
   parser.add_option('--preserve-tryjobs', action='store_true',
                     help='instruct the CQ to let tryjobs running even after '
                          'new patchsets are uploaded instead of canceling '


### PR DESCRIPTION
Some bots use git-cl to upload changes to Gerrit.
Add an option so those can set Bot-Commit+1 on upload instead of TBR and CR+1.

Change-Id: I5e80ddadedf6c4fe277f8984c35a603da923de5e Reviewed-on: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/2679780
Commit-Queue: Josip Sokcevic <sokcevic@google.com>
Reviewed-by: Josip Sokcevic <sokcevic@google.com>
Auto-Submit: Edward Lesmes <ehmaldonado@chromium.org>
(cherry picked from commit 10c3dd6f59787243559d651540042d9aa4f79c83) Reviewed-on: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/2797932
Auto-Submit: Michael Moss <mmoss@chromium.org>
Reviewed-by: Garrett Beaty <gbeaty@chromium.org>
Reviewed-by: Dirk Pranke <dpranke@google.com>
Reviewed-by: Dirk Pranke <dpranke@chromium.org>
Commit-Queue: Dirk Pranke <dpranke@google.com>
Commit-Queue: Dirk Pranke <dpranke@chromium.org>